### PR TITLE
Replaces Sci Kit Learn with Joblib + SciPy (closes #11)

### DIFF
--- a/profanity_check/profanity_check.py
+++ b/profanity_check/profanity_check.py
@@ -1,6 +1,5 @@
 import pkg_resources
-import numpy as np
-from sklearn.externals import joblib
+import joblib
 
 vectorizer = joblib.load(pkg_resources.resource_filename('profanity_check', 'data/vectorizer.joblib'))
 model = joblib.load(pkg_resources.resource_filename('profanity_check', 'data/model.joblib'))
@@ -12,4 +11,4 @@ def predict(texts):
   return model.predict(vectorizer.transform(texts))
 
 def predict_prob(texts):
-  return np.apply_along_axis(_get_profane_prob, 1, model.predict_proba(vectorizer.transform(texts)))
+  return [_get_profane_prob(i) for i in model.predict_proba(vectorizer.transform(texts))]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-scikit-learn>=0.20.2
+joblib==0.14.1
+scipy==1.4.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
   long_description_content_type="text/markdown",
   url="https://github.com/vzhou842/profanity-check",
   packages=setuptools.find_packages(),
-  install_requires=['scikit-learn>=0.20.2'],
+  install_requires=['joblib>=0.14.1', 'scipy>=1.4.1'],
   package_data={ 'profanity_check': ['data/model.joblib', 'data/vectorizer.joblib'] },
   classifiers=[
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
SciKit learn is a very large dependency that was not being directly used in this package. I've removed it and added joblib for the pipelining (was previously used, but through a transitive dependency) and scipy, which is required to unpickle the models artifacts.

## Summary of changes
- Declares explicit and direct dependencies used by the package.
- Reduces the footprint of this package (which is great for people using Docker where the smaller the image, the better)