### PR TITLE
Swap scikit learn dependency

### DIFF
--- a/profanity_check/__init__.py
+++ b/profanity_check/__init__.py
@@ -1,2 +1,2 @@
 from .profanity_check import predict, predict_prob
-__version__="1.0.2"
+__version__="1.0.3"

--- a/profanity_check/profanity_check.py
+++ b/profanity_check/profanity_check.py
@@ -1,6 +1,6 @@
 import pkg_resources
 import numpy as np
-from sklearn.externals import joblib
+import joblib
 
 vectorizer = joblib.load(pkg_resources.resource_filename('profanity_check', 'data/vectorizer.joblib'))
 model = joblib.load(pkg_resources.resource_filename('profanity_check', 'data/model.joblib'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 scikit-learn>=0.20.2
+joblib==0.14.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
   long_description_content_type="text/markdown",
   url="https://github.com/vzhou842/profanity-check",
   packages=setuptools.find_packages(),
-  install_requires=['scikit-learn>=0.20.2'],
+  install_requires=['joblib>=0.14.1', 'scikit-learn>=0.20.2'],
   package_data={ 'profanity_check': ['data/model.joblib', 'data/vectorizer.joblib'] },
   classifiers=[
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
As discussed in https://github.com/vzhou842/profanity-check/issues/11 importing joblib

* Changed version number
* Do not import joblib from `sklearn.externals`, use `import joblib`

Note:

Using the lastest version of sklearn getting the following warnings suggesting it might be a good idea to re-import the data and pin to latest version.

```log
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/base.py:313: UserWarning: Trying to unpickle estimator CountVectorizer from version 0.20.2 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.
  warnings.warn(
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/utils/deprecation.py:144: FutureWarning: The sklearn.svm.classes module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.svm. Anything that cannot be imported from sklearn.svm is now part of the private API.
  warnings.warn(message, FutureWarning)
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/base.py:313: UserWarning: Trying to unpickle estimator LinearSVC from version 0.20.2 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.
  warnings.warn(
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/externals/joblib/__init__.py:15: FutureWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.
  warnings.warn(msg, category=FutureWarning)
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/utils/deprecation.py:144: FutureWarning: The sklearn.preprocessing.label module is  deprecated in version 0.22 and will be removed in version 0.24. The corresponding classes / functions should instead be imported from sklearn.preprocessing. Anything that cannot be imported from sklearn.preprocessing is now part of the private API.
  warnings.warn(message, FutureWarning)
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/base.py:313: UserWarning: Trying to unpickle estimator LabelEncoder from version 0.20.2 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.
  warnings.warn(
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/base.py:313: UserWarning: Trying to unpickle estimator _SigmoidCalibration from version 0.20.2 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.
  warnings.warn(
/home/dimitry/.virtualenvs/profanity_check/lib/python3.8/site-packages/sklearn/base.py:313: UserWarning: Trying to unpickle estimator CalibratedClassifierCV from version 0.20.2 when using version 0.22.2.post1. This might lead to breaking code or invalid results. Use at your own risk.
  warnings.warn(
```