### PR TITLE
ImportError: cannot import name 'joblib'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-scikit-learn>=0.20.2
+scikit-learn==0.20.2
 joblib==0.14.1


### PR DESCRIPTION
The following error occurs when:

`from profanity_check import predict, predict_prob`

from sklearn.externals import joblib ImportError: cannot import name 'joblib'

The latest sklearn package doesn't export this symbol. Also a minor or patch version upgrade of scikit-learn gives the following warning, so this should be locked at `scikit-learn-0.20.2`:

```
sklearn/base.py:253: UserWarning: Trying to unpickle estimator CountVectorizer from version 0.20.2 when using version 0.20.3. This might lead to breaking code or invalid results. Use at your own risk.
  UserWarning)
```